### PR TITLE
Make `auth` option in configuration works

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -231,7 +231,7 @@ class Connection
             $connectionCredentials = [
                 'host' => $parsedUrl['host'] ?? '127.0.0.1',
                 'port' => $parsedUrl['port'] ?? 6379,
-                'auth' => $parsedUrl['pass'] ?? $parsedUrl['user'] ?? null,
+                'auth' => $parsedUrl['pass'] ?? $parsedUrl['user'] ?? $redisOptions['auth'] ?? null,
             ];
 
             $pathParts = explode('/', rtrim($parsedUrl['path'] ?? '', '/'));


### PR DESCRIPTION
```yaml
framework:
    messenger:
        transports:
            queue:
                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                options:
                    stream: 'cms'
                    delete_after_ack: false
                    auth: 'pa$$word'
                    serializer: !php/const Redis::SERIALIZER_JSON
```

This configuration results to this error:

```
In Connection.php line 510:

  NOAUTH Authentication required.
```

Because the `auth` option was never read from the options, only from the parsed DSN.