### PR TITLE
Support rediss protocol

### DIFF
--- a/Transport/RedisTransportFactory.php
+++ b/Transport/RedisTransportFactory.php
@@ -30,7 +30,7 @@ class RedisTransportFactory implements TransportFactoryInterface
 
     public function supports(string $dsn, array $options): bool
     {
-        return 0 === strpos($dsn, 'redis://');
+        return 0 === strpos($dsn, 'redis://') || 0 === strpos($dsn, 'rediss://');
     }
 }
 


### PR DESCRIPTION
Seems like support for `rediss` was added in the [main package](https://github.com/symfony/symfony/blob/e34cd7dd2c6d0b30d24cad443b8f964daa841d71/src/Symfony/Component/Messenger/Transport/TransportFactory.php#L46), but didn't propagate to this one.

Followed a trail from here - https://github.com/symfony/symfony/pull/39607